### PR TITLE
Fix DASH manifest refresh cadence and segment timeline precision

### DIFF
--- a/src/main/java/com/blazemeter/jmeter/videostreaming/core/MediaSegment.java
+++ b/src/main/java/com/blazemeter/jmeter/videostreaming/core/MediaSegment.java
@@ -35,7 +35,7 @@ public class MediaSegment {
   }
 
   public double getDurationSeconds() {
-    return (double) duration.getSeconds();
+    return duration.toMillis() / 1000.0;
   }
 
   public long getDurationMillis() {

--- a/src/main/java/com/blazemeter/jmeter/videostreaming/dash/DashSampler.java
+++ b/src/main/java/com/blazemeter/jmeter/videostreaming/dash/DashSampler.java
@@ -75,7 +75,8 @@ public class DashSampler extends VideoStreamingSampler<Manifest, DashMediaSegmen
       while (!mediaPlayback.hasEnded()) {
         if (mediaPlayback.needsManifestUpdate() && !initialLoop) {
           long awaitMillis = manifest.getReloadTimeMillis(
-              mediaPlayback.getLastSegment().getDurationMillis()
+              mediaPlayback.getLastSegment().getDurationMillis(),
+              timeMachine.now()
           );
           if (awaitMillis > 0) {
             timeMachine.awaitMillis(awaitMillis);
@@ -256,7 +257,7 @@ public class DashSampler extends VideoStreamingSampler<Manifest, DashMediaSegmen
     }
 
     private boolean needsManifestUpdate() {
-      return manifest.isDynamic() || !segmentBuilder.hasNext() && !periods.hasNext();
+      return !segmentBuilder.hasNext() && !periods.hasNext();
     }
 
   }

--- a/src/main/java/com/blazemeter/jmeter/videostreaming/dash/Manifest.java
+++ b/src/main/java/com/blazemeter/jmeter/videostreaming/dash/Manifest.java
@@ -84,13 +84,12 @@ public class Manifest extends com.blazemeter.jmeter.videostreaming.core.Manifest
     return mpd.getMinimumUpdatePeriod();
   }
 
-  public long getReloadTimeMillis(long segmentDurationMillis) {
-    // wait at least segment duration if minUpdatePeriod is 0 (or very small)
+  public long getReloadTimeMillis(long segmentDurationMillis, Instant now) {
     long maxIntervalTime = Math.max(
         mpd.getMinimumUpdatePeriod().toMillis(), segmentDurationMillis);
 
     return Math.max(maxIntervalTime - Duration.between(
-        lastDownloadTime, Instant.now()).toMillis(), 0);
+        lastDownloadTime, now).toMillis(), 0);
   }
 
   public Duration getBufferStartTime() {

--- a/src/main/java/com/blazemeter/jmeter/videostreaming/dash/segmentbuilders/MultiSegmentBuilder.java
+++ b/src/main/java/com/blazemeter/jmeter/videostreaming/dash/segmentbuilders/MultiSegmentBuilder.java
@@ -55,7 +55,7 @@ public abstract class MultiSegmentBuilder<T> extends BaseSegmentBuilder<T> {
         advanceUntilTime(reproductionStart, true);
       }
     } else if (lastSegment.getPeriod().equals(period)) {
-      advanceUntilTime(lastSegment.getEndTime().minus(scaledTimeToDuration(startTime)), false);
+      advanceUntilTime(lastSegment.getEndTime(), false);
     }
   }
 
@@ -71,11 +71,9 @@ public abstract class MultiSegmentBuilder<T> extends BaseSegmentBuilder<T> {
   protected abstract Supplier<Long> getSegmentDurationSupplier();
 
   private Duration scaledTimeToDuration(long scaledTime) {
-    //BigDecimal is used to avoid losing precision which is necessary to avoid miscalculating
-    //segment numbers or time stamps
-    return Duration.ofMillis(BigDecimal.valueOf(scaledTime)
+    return Duration.ofNanos(BigDecimal.valueOf(scaledTime)
         .divide(BigDecimal.valueOf(getTimescale()), 10, RoundingMode.HALF_UP)
-        .multiply(BigDecimal.valueOf(1000)).longValue());
+        .multiply(BigDecimal.valueOf(1_000_000_000L)).longValue());
   }
 
   private long getTimescale() {
@@ -92,20 +90,25 @@ public abstract class MultiSegmentBuilder<T> extends BaseSegmentBuilder<T> {
   private void advanceUntilTime(Duration time, boolean init) {
     Long segmentDuration = getSegmentDurationSupplier().get();
     if (segmentDuration != null) {
-      //BigDecimal is used to avoid losing precision which is necessary to avoid miscalculating
-      //segment numbers or time stamps
-      long incr = BigDecimal.valueOf(time.toMillis())
-          .divide(BigDecimal.valueOf(segmentDuration).multiply(BigDecimal.valueOf(1000)), 10,
-              RoundingMode.HALF_UP)
-          .multiply(BigDecimal.valueOf(getTimescale())).longValue();
+      Duration relativeTime = time.minus(scaledTimeToDuration(startTime));
+      long incr = BigDecimal.valueOf(relativeTime.toNanos())
+          .multiply(BigDecimal.valueOf(getTimescale()))
+          .divide(BigDecimal.valueOf(segmentDuration)
+              .multiply(BigDecimal.valueOf(1_000_000_000L)), 10, RoundingMode.HALF_UP)
+          .setScale(0, RoundingMode.HALF_UP)
+          .longValue();
       segmentNumber += incr;
       startTime += incr * segmentDuration;
     } else {
-      while (hasNext()
-          && scaledTimeToDuration(startTime + timelineSegment.duration).compareTo(time) <= 0) {
+      long ptoOffset = init ? getPresentationTimeOffset() : 0;
+      long targetTicks = BigDecimal.valueOf(time.toNanos())
+          .multiply(BigDecimal.valueOf(getTimescale()))
+          .divide(BigDecimal.valueOf(1_000_000_000L), 0, RoundingMode.HALF_UP)
+          .longValue() + ptoOffset;
+      while (hasNext() && startTime + timelineSegment.duration <= targetTicks) {
         long repetitionsUntilTime = BigDecimal
-            .valueOf(time.toMillis() * getTimescale() - startTime)
-            .divide(BigDecimal.valueOf(timelineSegment.duration), 10, RoundingMode.HALF_UP)
+            .valueOf(targetTicks - startTime)
+            .divide(BigDecimal.valueOf(timelineSegment.duration), 0, RoundingMode.HALF_UP)
             .longValue();
         long pendingRepetitions = timelineSegment.repetitions - timelineSegmentRepetitions + 1;
         long repetitions = Math.min(pendingRepetitions, repetitionsUntilTime);
@@ -114,12 +117,6 @@ public abstract class MultiSegmentBuilder<T> extends BaseSegmentBuilder<T> {
         timelineSegmentRepetitions += repetitions;
         moveToNextTimelineSegmentIfNeeded();
       }
-      /*
-      when initializing segments on manifest, at least return one segment.
-      This might happen due to rounding and double precision issues and due to potential no segments
-      yet generated containing publish time - minimum time buffer (which we use as reproduction
-      starting point)
-       */
       //TODO fix this and use proper buffering time instead of reproduction start time which is not
       // accurate and requires this workaround
       if (init && !hasNext()) {

--- a/src/test/java/com/blazemeter/jmeter/videostreaming/dash/DashSamplerTest.java
+++ b/src/test/java/com/blazemeter/jmeter/videostreaming/dash/DashSamplerTest.java
@@ -17,7 +17,7 @@ public class DashSamplerTest extends VideoStreamingSamplerTest {
   private static final String DEFAULT_SUBTITLES_ADAPTATION_SET = "minBandwidthSubtitlesEnglish";
   public static final int SEGMENTS_COUNT = 5;
   private static final double VIDEO_DURATION_SECONDS = 3.0;
-  private static final double AUDIO_DURATION_SECONDS = 3.0;
+  private static final double AUDIO_DURATION_SECONDS = 3.84;
   private static final double SUBTITLES_DURATION_SECONDS = 10.0;
   private static final int PLAYBACK_TIME_SECONDS = 5;
 
@@ -250,6 +250,63 @@ public class DashSamplerTest extends VideoStreamingSamplerTest {
       String adaptationSetId, long sequenceNumber, double duration) {
     return addDurationHeader(buildNamedSampleResult(buildSegmentName(type),
         buildLiveStreamingSegmentUri(type, adaptationSetId, sequenceNumber)), duration);
+  }
+
+  @Test
+  public void shouldAdvanceSegmentsAfterManifestRefreshWithLargeStartNumber() throws IOException {
+    String firstManifest = getResource("dynamicTimelineManifest.mpd");
+    String refreshedManifest = getResource("dynamicTimelineManifestRefreshed.mpd");
+
+    uriSampler.setupUriSampleResults(MANIFEST_URI,
+        buildBaseSampleResult(SAMPLER_NAME, MANIFEST_URI, firstManifest),
+        buildBaseSampleResult(SAMPLER_NAME, MANIFEST_URI, refreshedManifest));
+
+    long startSegNum = 1108993098L;
+    double seg1DurationSeconds = 1.433;
+    double seg2VideoDurationSeconds = 1.6;
+    double seg2AudioDurationSeconds = 1.6;
+
+    URI videoInitUri = URI.create(BASE_URI + "/init-v1.m4s");
+    uriSampler.setupUriSampleResults(videoInitUri,
+        buildNamedSampleResult(SAMPLER_NAME, videoInitUri));
+    URI videoSeg1Uri = URI.create(BASE_URI + "/seg-v1-" + startSegNum + ".m4s");
+    uriSampler.setupUriSampleResults(videoSeg1Uri,
+        buildNamedSampleResult(VIDEO_TYPE_NAME, videoSeg1Uri));
+    URI videoSeg2Uri = URI.create(BASE_URI + "/seg-v1-" + (startSegNum + 1) + ".m4s");
+    uriSampler.setupUriSampleResults(videoSeg2Uri,
+        buildNamedSampleResult(VIDEO_TYPE_NAME, videoSeg2Uri));
+
+    URI audioInitUri = URI.create(BASE_URI + "/init-a1.m4s");
+    uriSampler.setupUriSampleResults(audioInitUri,
+        buildNamedSampleResult(SAMPLER_NAME, audioInitUri));
+    URI audioSeg1Uri = URI.create(BASE_URI + "/seg-a1-" + startSegNum + ".m4s");
+    uriSampler.setupUriSampleResults(audioSeg1Uri,
+        buildNamedSampleResult(AUDIO_TYPE_NAME, audioSeg1Uri));
+    URI audioSeg2Uri = URI.create(BASE_URI + "/seg-a1-" + (startSegNum + 1) + ".m4s");
+    uriSampler.setupUriSampleResults(audioSeg2Uri,
+        buildNamedSampleResult(AUDIO_TYPE_NAME, audioSeg2Uri));
+
+    setPlaySeconds(3);
+    sampler.sample();
+
+    verifySampleResults(
+        buildBaseSampleResult(MANIFEST_NAME, MANIFEST_URI, firstManifest),
+        buildNamedSampleResult(buildInitSampleName(VIDEO_TYPE_NAME), videoInitUri),
+        addDurationHeader(
+            buildNamedSampleResult(buildSegmentName(VIDEO_TYPE_NAME), videoSeg1Uri),
+            seg1DurationSeconds),
+        buildNamedSampleResult(buildInitSampleName(AUDIO_TYPE_NAME), audioInitUri),
+        addDurationHeader(
+            buildNamedSampleResult(buildSegmentName(AUDIO_TYPE_NAME), audioSeg1Uri),
+            seg1DurationSeconds),
+        buildBaseSampleResult(MANIFEST_NAME, MANIFEST_URI, refreshedManifest),
+        addDurationHeader(
+            buildNamedSampleResult(buildSegmentName(VIDEO_TYPE_NAME), videoSeg2Uri),
+            seg2VideoDurationSeconds),
+        addDurationHeader(
+            buildNamedSampleResult(buildSegmentName(AUDIO_TYPE_NAME), audioSeg2Uri),
+            seg2AudioDurationSeconds)
+    );
   }
 
 }

--- a/src/test/resources/com/blazemeter/jmeter/videostreaming/dash/dynamicTimelineManifest.mpd
+++ b/src/test/resources/com/blazemeter/jmeter/videostreaming/dash/dynamicTimelineManifest.mpd
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<MPD xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xmlns="urn:mpeg:dash:schema:mpd:2011"
+     xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 http://standards.iso.org/ittf/PubliclyAvailableStandards/MPEG-DASH_schema_files/DASH-MPD.xsd"
+     type="dynamic"
+     minimumUpdatePeriod="PT2S"
+     availabilityStartTime="2024-01-01T00:00:00Z"
+     publishTime="2024-01-13T20:09:50Z"
+     minBufferTime="PT2S"
+     profiles="urn:mpeg:dash:profile:isoff-live:2011">
+  <Period id="1" start="PT0S">
+    <AdaptationSet id="1" contentType="video" mimeType="video/mp4"
+                   segmentAlignment="true">
+      <SegmentTemplate timescale="60000" startNumber="1108993098"
+                       presentationTimeOffset="100000000000"
+                       initialization="init-$RepresentationID$.m4s"
+                       media="seg-$RepresentationID$-$Number$.m4s">
+        <SegmentTimeline>
+          <S t="100000000000" d="86000"/>
+        </SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="v1" bandwidth="1000000" width="1920" height="1080"
+                      codecs="avc1.640028"/>
+    </AdaptationSet>
+    <AdaptationSet id="2" contentType="audio" mimeType="audio/mp4"
+                   segmentAlignment="true">
+      <SegmentTemplate timescale="48000" startNumber="1108993098"
+                       presentationTimeOffset="80000000000"
+                       initialization="init-$RepresentationID$.m4s"
+                       media="seg-$RepresentationID$-$Number$.m4s">
+        <SegmentTimeline>
+          <S t="80000000000" d="68800"/>
+        </SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="a1" bandwidth="128000" codecs="mp4a.40.2"/>
+    </AdaptationSet>
+  </Period>
+</MPD>

--- a/src/test/resources/com/blazemeter/jmeter/videostreaming/dash/dynamicTimelineManifestRefreshed.mpd
+++ b/src/test/resources/com/blazemeter/jmeter/videostreaming/dash/dynamicTimelineManifestRefreshed.mpd
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<MPD xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xmlns="urn:mpeg:dash:schema:mpd:2011"
+     xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 http://standards.iso.org/ittf/PubliclyAvailableStandards/MPEG-DASH_schema_files/DASH-MPD.xsd"
+     type="dynamic"
+     minimumUpdatePeriod="PT2S"
+     availabilityStartTime="2024-01-01T00:00:00Z"
+     publishTime="2024-01-13T20:09:52Z"
+     minBufferTime="PT2S"
+     profiles="urn:mpeg:dash:profile:isoff-live:2011">
+  <Period id="1" start="PT0S">
+    <AdaptationSet id="1" contentType="video" mimeType="video/mp4"
+                   segmentAlignment="true">
+      <SegmentTemplate timescale="60000" startNumber="1108993098"
+                       presentationTimeOffset="100000000000"
+                       initialization="init-$RepresentationID$.m4s"
+                       media="seg-$RepresentationID$-$Number$.m4s">
+        <SegmentTimeline>
+          <S t="100000000000" d="86000"/>
+          <S t="100000086000" d="96000"/>
+        </SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="v1" bandwidth="1000000" width="1920" height="1080"
+                      codecs="avc1.640028"/>
+    </AdaptationSet>
+    <AdaptationSet id="2" contentType="audio" mimeType="audio/mp4"
+                   segmentAlignment="true">
+      <SegmentTemplate timescale="48000" startNumber="1108993098"
+                       presentationTimeOffset="80000000000"
+                       initialization="init-$RepresentationID$.m4s"
+                       media="seg-$RepresentationID$-$Number$.m4s">
+        <SegmentTimeline>
+          <S t="80000000000" d="68800"/>
+          <S t="80000068800" d="76800"/>
+        </SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="a1" bandwidth="128000" codecs="mp4a.40.2"/>
+    </AdaptationSet>
+  </Period>
+</MPD>


### PR DESCRIPTION
This pull request improves live streaming behavior and timing accuracy in the video streaming plugin: DASH dynamic manifests refresh at the right cadence, segment timeline math stays correct for large SegmentTimeline / startNumber cases

### Changes
#### DASH

- Refresh the manifest only when no further segments (and periods) are available from the current MPD, instead of treating type="dynamic" alone as a refresh trigger.
- Compute reload delay using the sampler timeMachine.now() (with Manifest.getReloadTimeMillis(..., Instant now)), so waits respect simulated time and tests stay deterministic.
- MultiSegmentBuilder: More precise tick/time handling (nanosecond-based scaling), corrected advancement when continuing in the same period after the last segment, and improved SegmentTimeline iteration (including presentationTimeOffset on init).
- Tests: New fixtures and DashSamplerTest coverage for manifest refresh with large startNumber; adjusted audio duration expectation where sub-second accuracy applies.
- `MediaSegment.getDurationSeconds()` uses millisecond-based fractional seconds instead of truncating to whole seconds.
