### PR TITLE
Setup SonarQube release and GitHub deployment

### DIFF
--- a/.github/maven-central-deploy.sh
+++ b/.github/maven-central-deploy.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+#
+# Deploys release artifacts to Maven Central via the Sonatype Central Portal.
+#
+# Required environment variables: GPG_SECRET_KEYS, GPG_OWNERTRUST, GPG_EXECUTABLE
+
+set -eo pipefail
+
+echo $GPG_SECRET_KEYS | base64 --decode | $GPG_EXECUTABLE --batch --import
+echo $GPG_OWNERTRUST | base64 --decode | $GPG_EXECUTABLE --batch --import-ownertrust
+mvn --batch-mode deploy -Prelease -DskipTests --settings .github/settings.xml

--- a/.github/settings.xml
+++ b/.github/settings.xml
@@ -1,0 +1,27 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                          https://maven.apache.org/xsd/settings-1.0.0.xsd">
+
+  <servers>
+    <server>
+      <id>central</id>
+      <username>${env.SONATYPE_USERNAME}</username>
+      <password>${env.SONATYPE_PASSWORD}</password>
+    </server>
+  </servers>
+
+  <profiles>
+    <profile>
+      <id>central</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <properties>
+        <gpg.executable>${env.GPG_EXECUTABLE}</gpg.executable>
+        <gpg.passphrase>${env.GPG_PASSPHRASE}</gpg.passphrase>
+      </properties>
+    </profile>
+  </profiles>
+
+</settings>

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,92 @@
+name: release
+run-name: release ${{ inputs.version }}
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version (e.g. 3.4.0)"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Ensure release runs on master
+        run: |
+          if [ "${{ github.ref_name }}" != "master" ]; then
+            echo "Release must be triggered from master branch."
+            exit 1
+          fi
+
+      - name: Set up Java 8
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "8"
+          cache: maven
+
+      - name: Create release draft
+        uses: ncipollo/release-action@v1
+        with:
+          tag: v${{ inputs.version }}
+          name: ${{ inputs.version }}
+          draft: true
+
+      - name: Set maven project version
+        run: mvn --batch-mode --no-transfer-progress versions:set -DnewVersion=${{ inputs.version }}
+
+      - name: Commit release version
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "[skip ci] Set release version ${{ inputs.version }}"
+          branch: master
+          file_pattern: "pom.xml"
+
+      - name: Build and test
+        run: xvfb-run -a mvn --batch-mode --no-transfer-progress clean install
+
+      - name: Publish to Maven Central
+        run: .github/maven-central-deploy.sh
+        env:
+          GPG_SECRET_KEYS: ${{ secrets.GPG_SECRET_KEYS }}
+          GPG_OWNERTRUST: ${{ secrets.GPG_OWNERTRUST }}
+          GPG_EXECUTABLE: gpg
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+
+      - name: Publish GitHub release
+        uses: ncipollo/release-action@v1
+        with:
+          tag: v${{ inputs.version }}
+          allowUpdates: true
+          omitNameDuringUpdate: true
+          omitBodyDuringUpdate: true
+          updateOnlyUnreleased: true
+          draft: false
+          artifacts: "target/jmeter-bzm-hls-${{ inputs.version }}.jar"
+
+      - name: Compute next SNAPSHOT version
+        run: |
+          IFS='.' read -r major minor patch <<< "${{ inputs.version }}"
+          echo "SNAPSHOT_VERSION=${major}.${minor}.$((patch + 1))-SNAPSHOT" >> $GITHUB_ENV
+
+      - name: Update to next SNAPSHOT version
+        run: mvn --batch-mode --no-transfer-progress versions:set -DnewVersion=${{ env.SNAPSHOT_VERSION }}
+
+      - name: Commit SNAPSHOT version
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "[skip ci] Set SNAPSHOT version ${{ env.SNAPSHOT_VERSION }}"
+          branch: master
+          file_pattern: "pom.xml"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,7 +74,7 @@ jobs:
           omitBodyDuringUpdate: true
           updateOnlyUnreleased: true
           draft: false
-          artifacts: "target/jmeter-bzm-hls-${{ inputs.version }}.jar"
+          artifacts: "target/jmeter-test/lib/*.jar"
 
       - name: Compute next SNAPSHOT version
         run: |

--- a/pom.xml
+++ b/pom.xml
@@ -262,7 +262,9 @@
                             <includeArtifactIds>
                                 hlsparserj, jackson-annotations, jackson-core, jackson-databind,
                                 jackson-dataformat-xml, jackson-module-jaxb-annotations,
-                                stax2-api, woodstox-core
+                                stax2-api, woodstox-core,
+                                mpd-tools, jmeter-bzm-commons,
+                                jakarta.xml.bind-api, jakarta.activation-api
                             </includeArtifactIds>
                             <outputDirectory>${project.build.directory}/jmeter-test/lib</outputDirectory>
                         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -5,8 +5,17 @@
 
     <groupId>com.blazemeter.jmeter</groupId>
     <artifactId>jmeter-bzm-hls</artifactId>
-    <version>3.3.0</version>
+    <version>3.4.0-SNAPSHOT</version>
     <name>Video Streaming Sampler as JMeter plugin</name>
+    <description>BlazeMeter Video Streaming Plugin for JMeter (HLS and MPEG-DASH)</description>
+    <licenses>
+        <license>
+            <name>The Apache Software License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+    <url>https://github.com/Blazemeter/HLSPlugin</url>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -15,11 +24,17 @@
     </properties>
 
     <scm>
-        <connection>scm:git:git@github.com:Blazemeter/HLSPlugin.git</connection>
-        <developerConnection>scm:git:git@github.com:Blazemeter/HLSPlugin.git
-        </developerConnection>
-        <url>https://github.com/Blazemeter/HLSPlugin</url>
+        <connection>scm:git:git://github.com/Blazemeter/HLSPlugin.git</connection>
+        <developerConnection>scm:git:ssh://github.com:Blazemeter/HLSPlugin.git</developerConnection>
+        <url>https://github.com/Blazemeter/HLSPlugin/tree/master</url>
     </scm>
+    <developers>
+        <developer>
+            <id>team</id>
+            <name>blazelabs</name>
+            <email>blazelabs@perforce.com</email>
+        </developer>
+    </developers>
     <repositories>
         <repository>
             <id>jitpack.io</id>
@@ -341,6 +356,99 @@
                                 </goals>
                             </execution>
                         </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-enforcer-plugin</artifactId>
+                        <version>3.6.2</version>
+                        <executions>
+                            <execution>
+                                <id>enforce-no-snapshots</id>
+                                <goals>
+                                    <goal>enforce</goal>
+                                </goals>
+                                <configuration>
+                                    <rules>
+                                        <requireReleaseDeps>
+                                            <message>No Snapshots Allowed!</message>
+                                            <excludes>
+                                                <exclude>org.apache.maven:maven-core</exclude>
+                                                <exclude>org.apache.maven.plugins:*</exclude>
+                                            </excludes>
+                                        </requireReleaseDeps>
+                                    </rules>
+                                    <fail>true</fail>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <version>3.3.0</version>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <version>3.5.0</version>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <source>8</source>
+                            <failOnError>false</failOnError>
+                            <doclint>none</doclint>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>3.1.0</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                                <configuration>
+                                    <gpgArguments>
+                                        <arg>--pinentry-mode</arg>
+                                        <arg>loopback</arg>
+                                    </gpgArguments>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>0.9.0</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <publishingServerId>central</publishingServerId>
+                            <autoPublish>true</autoPublish>
+                            <waitUntil>published</waitUntil>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>


### PR DESCRIPTION
This pull request introduces a complete automation for releasing artifacts to Maven Central, including the necessary Maven configuration, a GitHub Actions workflow, and enhancements to the `pom.xml` for compliance with central repository requirements. The changes ensure releases are properly signed, documented, and published in a repeatable, secure way.

**Release Automation and Workflow Integration:**

- Added a new GitHub Actions workflow (`.github/workflows/release.yml`) to automate the release process, including version setting, artifact building, signing, deployment to Maven Central, and updating the project version to the next snapshot.
- Introduced a shell script (`.github/maven-central-deploy.sh`) for securely importing GPG keys and deploying artifacts to Maven Central using Maven.
- Added a Maven settings file (`.github/settings.xml`) to configure authentication and GPG signing using GitHub Actions secrets and environment variables.

**Maven Project Configuration Improvements:**

- Enhanced `pom.xml` with required metadata for Maven Central: added a project description, license, project URL, developer information, and improved SCM connection URLs. [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L8-R18) [[2]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L18-R37)
- Added a new Maven `release` profile to `pom.xml` that enforces no snapshot dependencies, attaches sources and javadocs, signs artifacts with GPG, and configures publishing via Sonatype Central.