### PR TITLE
Update hlsparserj dependency to be consumed from maven central

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,9 +38,9 @@
             <version>${jmeter.version}</version>
         </dependency>
         <dependency>
-          <groupId>com.github.blazemeter</groupId>
+          <groupId>com.blazemeter</groupId>
           <artifactId>hlsparserj</artifactId>
-          <version>hlsparserj-1.0.1</version>
+          <version>1.0.2</version>
         </dependency>
         <dependency>
             <groupId>com.github.blazemeter</groupId>


### PR DESCRIPTION
This pull request makes a minor update to the project's dependencies in `pom.xml`. It updates the group ID and version for the `hlsparserj` library to use the official group and a newer version.

- Dependency updates:
  * Changed the group ID for `hlsparserj` from `com.github.blazemeter` to `com.blazemeter` and updated the version from `hlsparserj-1.0.1` to `1.0.2` in `pom.xml`.