### PR TITLE
Performance improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,55 @@ The sampler will automatically add an `X-MEDIA-SEGMENT-DURATION` HTTP response h
 
 In the case of MPEG DASH, the View Results Tree Listener displays the resultant samples with the associated type (manifest, inits and segments for media, audio and subtitles) to easily identify them as well.
 
+## Memory tuning: response data release
+
+To reduce JVM memory usage during large/long load tests, the sampler can release
+in-memory response bodies after each sample has been measured and passed to
+listeners. Two JMeter properties control this behavior (both read once at first
+use and cached for the JVM lifetime — they cannot be changed mid-run via
+`${__setProperty()}` without restarting JMeter):
+
+### Segment bodies (default: release enabled)
+
+    hls.sampler.releaseSegmentResponseData=true   # default
+
+What it affects:
+
+- Applies to HLS and DASH **media and init segment** samples.
+- Performance metrics are NOT affected: bytes received, latency, throughput, response
+  codes, headers (including `X-MEDIA-SEGMENT-DURATION`) and download order are all preserved.
+- Only the raw segment **payload bytes** are dropped.
+
+When to disable (set to `false` in `user.properties` or via `-J`):
+
+- You need to inspect or assert on the actual segment binary content.
+
+    jmeter -Jhls.sampler.releaseSegmentResponseData=false ...
+
+### Playlist and manifest bodies (default: release disabled)
+
+    hls.sampler.releasePlaylistResponseData=false   # default
+
+What it affects:
+
+- Applies to HLS **master/media/audio/subtitle playlists** and DASH **manifest**
+  samples on the playback loop (the 3-arg `downloadPlaylist` path used during sampling).
+- Variant-discovery requests (`getVariants` / GUI "Load Playlist") are not affected.
+- Playlists and manifests are small; enable only when you want to trim retained
+  `SampleResult` text during long soaks.
+
+When to enable:
+
+    jmeter -Jhls.sampler.releasePlaylistResponseData=true ...
+
+### GUI / View Results Tree caveat (both properties)
+
+Response bodies are cleared synchronously right after listeners are notified.
+In **GUI mode** with "Save Response Data" enabled, View Results Tree renders
+bodies lazily when you click a row — after the body has already been cleared.
+Released samples appear with empty response data in the tree. Use non-GUI mode
+for production-like soaks, or disable release when debugging response content.
+
 ## Assertions and Post Processors
 
 The plugin supports adding assertions and post processors on any of the potential types of sample results (master playlist, media playlist, media segment, audio playlist, audio segment, subtitles, subtitles playlist and subtitles segment).

--- a/src/main/java/com/blazemeter/jmeter/videostreaming/core/VideoStreamingSampler.java
+++ b/src/main/java/com/blazemeter/jmeter/videostreaming/core/VideoStreamingSampler.java
@@ -20,6 +20,7 @@ import java.util.stream.Stream;
 
 import org.apache.jmeter.protocol.http.sampler.HTTPSampleResult;
 import org.apache.jmeter.samplers.SampleResult;
+import org.apache.jmeter.util.JMeterUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -28,11 +29,17 @@ public abstract class VideoStreamingSampler<T, U extends MediaSegment> {
   public static final String SUBTITLES_TYPE_NAME = "subtitles";
   public static final String VIDEO_TYPE_NAME = "video";
   public static final String AUDIO_TYPE_NAME = "audio";
+  public static final String RELEASE_SEGMENT_RESPONSE_DATA_PROP =
+      "hls.sampler.releaseSegmentResponseData";
+  public static final String RELEASE_PLAYLIST_RESPONSE_DATA_PROP =
+      "hls.sampler.releasePlaylistResponseData";
   protected static final String MASTER_TYPE_NAME = "master";
   protected static final String MEDIA_TYPE_NAME = "media";
   private static final byte[] BOM_BYTES = {(byte) 0xEF, (byte) 0xBB, (byte) 0xBF};
 
   private static final Logger LOG = LoggerFactory.getLogger(VideoStreamingSampler.class);
+  private static volatile Boolean releaseSegmentResponseData;
+  private static volatile Boolean releasePlaylistResponseData;
 
   protected final VideoStreamingHttpClient httpClient;
   protected final TimeMachine timeMachine;
@@ -116,6 +123,7 @@ public abstract class VideoStreamingSampler<T, U extends MediaSegment> {
     if (!playlistResult.isSuccessful()) {
       String playlistName = name.apply(null);
       sampleResultProcessor.accept(playlistName, playlistResult);
+      releasePlaylistResponseBodyIfEnabled(playlistResult);
       throw new PlaylistDownloadException(playlistName, uri);
     }
 
@@ -141,9 +149,11 @@ public abstract class VideoStreamingSampler<T, U extends MediaSegment> {
         playlistResult.setRequestHeaders(requestHeaders + videoType);
       }
       sampleResultProcessor.accept(name.apply(playlist), playlistResult);
+      releasePlaylistResponseBodyIfEnabled(playlistResult);
       return playlist;
     } catch (PlaylistParsingException e) {
       sampleResultProcessor.accept(name.apply(null), baseSampler.errorResult(playlistResult, e));
+      releasePlaylistResponseBodyIfEnabled(playlistResult);
       throw e;
     }
   }
@@ -196,8 +206,14 @@ public abstract class VideoStreamingSampler<T, U extends MediaSegment> {
    */
   private String getPlaylistContents(HTTPSampleResult result) {
     byte[] bytes = result.getResponseData();
-    return (bytesStartsWith(bytes, BOM_BYTES))
-        ? new String(bytes, StandardCharsets.UTF_8) : result.getResponseDataAsString();
+    if (bytes == null || bytes.length == 0) {
+      return "";
+    }
+    int offset = 0;
+    if (bytesStartsWith(bytes, BOM_BYTES)) {
+      offset = BOM_BYTES.length;
+    }
+    return new String(bytes, offset, bytes.length - offset, StandardCharsets.UTF_8);
   }
 
   private boolean bytesStartsWith(byte[] bytes, byte[] start) {
@@ -239,6 +255,7 @@ public abstract class VideoStreamingSampler<T, U extends MediaSegment> {
         result.getResponseHeaders() + "X-MEDIA-SEGMENT-DURATION: " + segment.getDurationSeconds()
             + "\n");
     sampleResultProcessor.accept(VideoStreamingSampler.buildSegmentName(type), result);
+    releaseSegmentResponseBodyIfEnabled(result);
   }
 
   protected void downloadInitSegment(InitializationSegment initializationSegment, String type) {
@@ -247,6 +264,53 @@ public abstract class VideoStreamingSampler<T, U extends MediaSegment> {
         + (initializationSegment.getByteOffset() + initializationSegment.getByteLength() - 1));
     SampleResult result = httpClient.downloadUri(initializationSegment.getUri());
     sampleResultProcessor.accept(VideoStreamingSampler.buildInitSegmentName(type), result);
+    releaseSegmentResponseBodyIfEnabled(result);
+  }
+
+  protected void releaseSegmentResponseBodyIfEnabled(SampleResult result) {
+    if (isReleaseSegmentResponseDataEnabled()) {
+      clearResponseBodyPreservingMetrics(result);
+    }
+  }
+
+  protected void releasePlaylistResponseBodyIfEnabled(SampleResult result) {
+    if (isReleasePlaylistResponseDataEnabled()) {
+      clearResponseBodyPreservingMetrics(result);
+    }
+  }
+
+  private static void clearResponseBodyPreservingMetrics(SampleResult result) {
+    long bytes = result.getBytesAsLong();
+    long bodySize = result.getBodySizeAsLong();
+    result.setResponseData(new byte[0]);
+    result.setBytes(bytes);
+    result.setBodySize(bodySize);
+  }
+
+  static boolean isReleaseSegmentResponseDataEnabled() {
+    if (releaseSegmentResponseData == null) {
+      releaseSegmentResponseData =
+          JMeterUtils.getPropDefault(RELEASE_SEGMENT_RESPONSE_DATA_PROP, true);
+    }
+    return releaseSegmentResponseData;
+  }
+
+  static boolean isReleasePlaylistResponseDataEnabled() {
+    if (releasePlaylistResponseData == null) {
+      releasePlaylistResponseData =
+          JMeterUtils.getPropDefault(RELEASE_PLAYLIST_RESPONSE_DATA_PROP, false);
+    }
+    return releasePlaylistResponseData;
+  }
+
+  @VisibleForTesting
+  public static void resetReleaseSegmentResponseDataCache() {
+    releaseSegmentResponseData = null;
+  }
+
+  @VisibleForTesting
+  public static void resetReleasePlaylistResponseDataCache() {
+    releasePlaylistResponseData = null;
   }
 
   @VisibleForTesting

--- a/src/main/java/com/blazemeter/jmeter/videostreaming/dash/DashSampler.java
+++ b/src/main/java/com/blazemeter/jmeter/videostreaming/dash/DashSampler.java
@@ -235,6 +235,7 @@ public class DashSampler extends VideoStreamingSampler<Manifest, DashMediaSegmen
       }
       SampleResult result = httpClient.downloadUri(uri);
       sampleResultProcessor.accept(buildInitSegmentName(type), result);
+      releaseSegmentResponseBodyIfEnabled(result);
     }
 
     private void downloadUntilTimeSecond(double untilTimeSecond) throws InterruptedException {

--- a/src/main/java/com/blazemeter/jmeter/videostreaming/dash/Manifest.java
+++ b/src/main/java/com/blazemeter/jmeter/videostreaming/dash/Manifest.java
@@ -18,6 +18,13 @@ import java.util.stream.Collectors;
 
 public class Manifest extends com.blazemeter.jmeter.videostreaming.core.Manifest {
 
+  /**
+   * Shared parser instance. Jackson {@code XmlMapper} read paths are thread-safe after
+   * configuration; concurrent {@code parse} calls are validated by
+   * {@code ManifestTest.shouldParseManifestConsistentlyWhenParsingConcurrentlyFromSharedParser}.
+   */
+  private static final MPDParser MPD_PARSER = new MPDParser();
+
   private final MPD mpd;
   private final Instant lastDownloadTime;
   private Instant playbackStartTime;
@@ -54,7 +61,7 @@ public class Manifest extends com.blazemeter.jmeter.videostreaming.core.Manifest
   public static Manifest fromUriAndBody(URI uri, String body, Instant timestamp)
       throws PlaylistParsingException {
     try {
-      return new Manifest(uri, new MPDParser().parse(body), timestamp);
+      return new Manifest(uri, MPD_PARSER.parse(body), timestamp);
     } catch (Exception e) {
       throw new PlaylistParsingException(uri, e);
     }

--- a/src/main/java/com/blazemeter/jmeter/videostreaming/hls/Playlist.java
+++ b/src/main/java/com/blazemeter/jmeter/videostreaming/hls/Playlist.java
@@ -56,7 +56,11 @@ public class Playlist extends Manifest {
   public static Playlist fromUriAndBody(URI uri, String body, Instant timestamp)
       throws PlaylistParsingException {
     try {
-      AbstractPlaylist p = PlaylistFactory.parsePlaylist(TWELVE, body.replace("\r", ""));
+      String normalizedBody = body;
+      if (body.indexOf('\r') >= 0) {
+        normalizedBody = body.replace("\r", "");
+      }
+      AbstractPlaylist p = PlaylistFactory.parsePlaylist(TWELVE, normalizedBody);
       if (p.getTags().isEmpty()) {
         throw new PlaylistParsingException(uri, "No playlist tags found");
       }

--- a/src/test/java/com/blazemeter/jmeter/videostreaming/VideoStreamingSamplerTest.java
+++ b/src/test/java/com/blazemeter/jmeter/videostreaming/VideoStreamingSamplerTest.java
@@ -7,9 +7,11 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.blazemeter.jmeter.JMeterTestUtils;
 import com.blazemeter.jmeter.videostreaming.core.SampleResultProcessor;
 import com.blazemeter.jmeter.videostreaming.core.TimeMachine;
 import com.blazemeter.jmeter.videostreaming.core.VideoStreamingHttpClient;
+import com.blazemeter.jmeter.videostreaming.core.VideoStreamingSampler;
 import com.google.common.base.Charsets;
 import com.google.common.io.Resources;
 import java.io.IOException;
@@ -21,6 +23,7 @@ import java.util.Iterator;
 import java.util.function.Function;
 import org.apache.jmeter.protocol.http.sampler.HTTPSampleResult;
 import org.apache.jmeter.samplers.SampleResult;
+import org.apache.jmeter.util.JMeterUtils;
 import org.junit.Before;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
@@ -125,6 +128,11 @@ public abstract class VideoStreamingSamplerTest {
 
   @Before
   public void setUp() {
+    JMeterTestUtils.setupJmeterEnv();
+    JMeterUtils.setProperty(VideoStreamingSampler.RELEASE_SEGMENT_RESPONSE_DATA_PROP, "false");
+    JMeterUtils.setProperty(VideoStreamingSampler.RELEASE_PLAYLIST_RESPONSE_DATA_PROP, "false");
+    VideoStreamingSampler.resetReleaseSegmentResponseDataCache();
+    VideoStreamingSampler.resetReleasePlaylistResponseDataCache();
     buildSampler(uriSampler);
   }
 

--- a/src/test/java/com/blazemeter/jmeter/videostreaming/dash/ManifestTest.java
+++ b/src/test/java/com/blazemeter/jmeter/videostreaming/dash/ManifestTest.java
@@ -1,0 +1,96 @@
+package com.blazemeter.jmeter.videostreaming.dash;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.base.Charsets;
+import com.google.common.io.Resources;
+import java.io.IOException;
+import java.net.URI;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import org.junit.Test;
+
+public class ManifestTest {
+
+  private static final URI TEST_URI = URI.create("http://test/manifest.mpd");
+  private static final int THREAD_COUNT = 32;
+
+  @Test
+  public void shouldParseManifestConsistentlyWhenParsingConcurrentlyFromSharedParser()
+      throws Exception {
+    String defaultBody = loadResource("defaultManifest.mpd");
+    String dynamicBody = loadResource("dynamicTimelineManifest.mpd");
+    String refreshedBody = loadResource("dynamicTimelineManifestRefreshed.mpd");
+
+    Manifest expectedDefault = Manifest.fromUriAndBody(TEST_URI, defaultBody, Instant.EPOCH);
+    Manifest expectedDynamic = Manifest.fromUriAndBody(TEST_URI, dynamicBody, Instant.EPOCH);
+    Manifest expectedRefreshed = Manifest.fromUriAndBody(TEST_URI, refreshedBody, Instant.EPOCH);
+
+    List<Callable<Manifest>> tasks = new ArrayList<>();
+    for (int i = 0; i < THREAD_COUNT; i++) {
+      String body = i % 3 == 0 ? defaultBody : (i % 3 == 1 ? dynamicBody : refreshedBody);
+      tasks.add(() -> Manifest.fromUriAndBody(TEST_URI, body, Instant.EPOCH));
+    }
+
+    List<Manifest> results = runConcurrently(tasks);
+    for (int i = 0; i < results.size(); i++) {
+      Manifest parsed = results.get(i);
+      Manifest expected = i % 3 == 0 ? expectedDefault : (i % 3 == 1 ? expectedDynamic
+          : expectedRefreshed);
+      assertManifestEquivalent(parsed, expected);
+    }
+  }
+
+  private static void assertManifestEquivalent(Manifest parsed, Manifest expected) {
+    assertThat(parsed.isDynamic()).isEqualTo(expected.isDynamic());
+    assertThat(parsed.getPeriods()).hasSize(expected.getPeriods().size());
+    assertThat(parsed.getBandwidths()).isEqualTo(expected.getBandwidths());
+    assertThat(parsed.getResolutions()).isEqualTo(expected.getResolutions());
+    if (expected.isDynamic()) {
+      assertThat(parsed.getMinimumUpdatePeriod()).isEqualTo(expected.getMinimumUpdatePeriod());
+    } else {
+      assertThat(parsed.getMediaPresentationDuration())
+          .isEqualTo(expected.getMediaPresentationDuration());
+    }
+  }
+
+  private static List<Manifest> runConcurrently(List<Callable<Manifest>> tasks) throws Exception {
+    ExecutorService executor = Executors.newFixedThreadPool(THREAD_COUNT);
+    try {
+      List<Future<Manifest>> futures = executor.invokeAll(tasks);
+      List<Manifest> results = new ArrayList<>(futures.size());
+      for (Future<Manifest> future : futures) {
+        results.add(future.get());
+      }
+      return results;
+    } finally {
+      executor.shutdownNow();
+    }
+  }
+
+  private static String loadResource(String name) throws IOException {
+    return Resources.toString(Resources.getResource(ManifestTest.class, name), Charsets.UTF_8);
+  }
+
+  @Test
+  public void shouldParseStaticManifestWhenFromUriAndBody() throws Exception {
+    String body = loadResource("defaultManifest.mpd");
+    Manifest manifest = Manifest.fromUriAndBody(TEST_URI, body, Instant.EPOCH);
+    assertThat(manifest.isDynamic()).isFalse();
+    assertThat(manifest.getPeriods()).hasSize(1);
+  }
+
+  @Test
+  public void shouldParseDynamicManifestWhenFromUriAndBody() throws Exception {
+    String body = loadResource("dynamicTimelineManifest.mpd");
+    Manifest manifest = Manifest.fromUriAndBody(TEST_URI, body, Instant.EPOCH);
+    assertThat(manifest.isDynamic()).isTrue();
+    assertThat(manifest.getMinimumUpdatePeriod()).isNotNull();
+  }
+
+}

--- a/src/test/java/com/blazemeter/jmeter/videostreaming/hls/HlsSamplerTest.java
+++ b/src/test/java/com/blazemeter/jmeter/videostreaming/hls/HlsSamplerTest.java
@@ -31,6 +31,7 @@ import java.util.concurrent.Semaphore;
 import java.util.function.Function;
 import org.apache.jmeter.protocol.http.sampler.HTTPSampleResult;
 import org.apache.jmeter.samplers.SampleResult;
+import org.apache.jmeter.util.JMeterUtils;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
@@ -951,6 +952,53 @@ public class HlsSamplerTest extends VideoStreamingSamplerTest {
     verifySampleResults(
         buildBaseSampleResult(MEDIA_PLAYLIST_SAMPLE_NAME, MASTER_URI, mediaPlaylist),
         buildMediaSegmentSampleResult(5));
+  }
+
+  @Test
+  public void shouldReleaseSegmentResponseDataAfterProcessingWhenReleaseSegmentResponseDataEnabled()
+      throws Exception {
+    JMeterUtils.setProperty(VideoStreamingSampler.RELEASE_SEGMENT_RESPONSE_DATA_PROP, "true");
+    VideoStreamingSampler.resetReleaseSegmentResponseDataCache();
+    try {
+      String mediaPlaylist = getResource(SIMPLE_MEDIA_PLAYLIST_NAME);
+      HTTPSampleResult segmentResult = buildMediaSegmentSampleResult(1);
+      segmentResult.setResponseData("segment-payload", Charsets.UTF_8.name());
+      long bytesBeforeRelease = segmentResult.getBytesAsLong();
+
+      setupUriSamplerPlaylist(MASTER_URI, mediaPlaylist);
+      uriSampler.setupUriSampleResults(buildSegmentUri(MEDIA_TYPE_NAME, 1), segmentResult);
+      setPlaySeconds(MEDIA_SEGMENT_DURATION);
+      sampler.sample();
+
+      assertThat(segmentResult.getResponseData()).isEmpty();
+      assertThat(segmentResult.getBytesAsLong()).isEqualTo(bytesBeforeRelease);
+    } finally {
+      JMeterUtils.setProperty(VideoStreamingSampler.RELEASE_SEGMENT_RESPONSE_DATA_PROP, "false");
+      VideoStreamingSampler.resetReleaseSegmentResponseDataCache();
+    }
+  }
+
+  @Test
+  public void shouldReleasePlaylistResponseDataAfterProcessingWhenReleasePlaylistResponseDataEnabled()
+      throws Exception {
+    JMeterUtils.setProperty(VideoStreamingSampler.RELEASE_PLAYLIST_RESPONSE_DATA_PROP, "true");
+    VideoStreamingSampler.resetReleasePlaylistResponseDataCache();
+    try {
+      String mediaPlaylist = getResource(SIMPLE_MEDIA_PLAYLIST_NAME);
+      HTTPSampleResult playlistResult = buildBaseSampleResult(SAMPLER_NAME, MASTER_URI,
+          mediaPlaylist);
+      long bytesBeforeRelease = playlistResult.getBytesAsLong();
+
+      uriSampler.setupUriSampleResults(MASTER_URI, playlistResult);
+      setPlaySeconds(MEDIA_SEGMENT_DURATION);
+      sampler.sample();
+
+      assertThat(playlistResult.getResponseData()).isEmpty();
+      assertThat(playlistResult.getBytesAsLong()).isEqualTo(bytesBeforeRelease);
+    } finally {
+      JMeterUtils.setProperty(VideoStreamingSampler.RELEASE_PLAYLIST_RESPONSE_DATA_PROP, "false");
+      VideoStreamingSampler.resetReleasePlaylistResponseDataCache();
+    }
   }
 
   @Test


### PR DESCRIPTION
This pull request introduces significant improvements to memory management and thread safety in the video streaming samplers, as well as enhancements to test coverage. The main updates include the ability to optionally release HTTP response data after processing to reduce memory usage, improved handling of playlist parsing, and new tests to ensure thread safety and correct behavior of these features.

**Memory management and response data handling:**

* Added new properties (`hls.sampler.releaseSegmentResponseData`, `hls.sampler.releasePlaylistResponseData`) to control whether segment and playlist HTTP response data are released after processing, reducing memory usage. Corresponding logic and helper methods were implemented in `VideoStreamingSampler`, and calls to release response data were added at appropriate points in both HLS and DASH samplers. 

* Updated tests to verify that response data is correctly released when the new properties are enabled, and ensured test isolation by resetting property caches and environment setup. 

**Playlist and manifest parsing improvements:**

* Improved playlist parsing in `Playlist.java` to only normalize line endings when necessary, avoiding unnecessary string replacements.

* In `Manifest.java`, introduced a shared, thread-safe `MPDParser` instance for DASH manifest parsing, and updated usage to improve efficiency and thread safety. 

**Test coverage and thread safety:**

* Added comprehensive tests for concurrent parsing of DASH manifests to ensure thread safety of the shared parser instance, as well as tests for both static and dynamic manifest parsing.

**Miscellaneous:**

* Added necessary imports and setup in test files to support new features and maintain test reliability.

These changes collectively improve the efficiency, scalability, and reliability of the video streaming samplers in both production and test environments.